### PR TITLE
suave - update TargetFramework from net46 to net461

### DIFF
--- a/suave/ApplicationName.fsproj
+++ b/suave/ApplicationName.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="<%= namespace %>.fs" />


### PR DESCRIPTION
Currently, after creating project from suave template it fails with "Target Restore not found".
Reason seems to be that paket.dependencies restricts framework to ">= net461" while fsproj targets net46.
After this change I'm able to build project created from the template.