### PR TITLE
Update dotnetcliVersion to 2.0.2 in build.fsx

### DIFF
--- a/.fake/build.fsx
+++ b/.fake/build.fsx
@@ -13,7 +13,7 @@ open System
 
 let buildDir  = "./build/"
 let appReferences = !! "/**/*.fsproj"
-let dotnetcliVersion = "2.0.0"
+let dotnetcliVersion = "2.0.2"
 let mutable dotnetExePath = "dotnet"
 
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
Hi!

First, thanks for everyone for building these tools!

The dotnetcliVersion is defined as `2.0.0`, but the latest version is `2.0.2`, so the build script tries to install dotnet sdk every time I run build because 2.0.2 != 2.0.0...

Build Console output:
```
...
Starting Target: InstallDotNetCLI (==> Clean)
dotnet --version
C:\Users\x\AppData\Local\dotnetcore\dotnet.exe --version
Deleting contents of C:\Users\x\AppData\Local\dotnetcore
Installing 'https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.0/dotnet-dev-win-x64.2.0.0.zip' to 'C:\Users\x\AppData\Local\Temp\dotnet-dev-win-x64.2.0.0.zip'
Installing 'https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.0.0/dotnet-sdk-2.0.0-win-x64.zip' to 'C:\Users\x\AppData\Local\Temp\dotnet-sdk-2.0.0-win-x64.zip'
dotnet cli path - C:\Users\x\AppData\Local\dotnetcore
 - C:\Users\x\AppData\Local\dotnetcore\dotnet.exe
 - C:\Users\x\AppData\Local\dotnetcore\LICENSE.txt
 - C:\Users\x\AppData\Local\dotnetcore\ThirdPartyNotices.txt
 - C:\Users\x\AppData\Local\dotnetcore\additionalDeps\
 - C:\Users\x\AppData\Local\dotnetcore\host\
 - C:\Users\x\AppData\Local\dotnetcore\sdk\
 - C:\Users\x\AppData\Local\dotnetcore\shared\
 - C:\Users\x\AppData\Local\dotnetcore\store\
Finished Target: InstallDotNetCLI
...
```

Changing it to "2.0.2" solves the problem:

```
...
Starting Target: InstallDotNetCLI (==> Clean)
dotnet --version
dotnetcli 2.0.2 already installed in PATH
Finished Target: InstallDotNetCLI
...
```

Or maybe Fake's `InstallDotNetSDK` could be extended to accept a range or min version?
https://github.com/fsharp/FAKE/blob/c14bb52f2c54fe63fd2ddf7852f2021817e8615d/src/app/FakeLib/DotNetCLIHelper.fs#L473